### PR TITLE
Remove security-only filter for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,3 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
Should ease the transition for GitHub-native Dependabot.